### PR TITLE
feat(tblocker): allow notifications without nft

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -14,3 +14,4 @@ services:
     environment:
       - NODE_PORT=2222
       - SECRET_KEY=""
+      # - TBLOCKER_NOTIFY_ALWAYS=true

--- a/src/common/config/app-config/config.schema.ts
+++ b/src/common/config/app-config/config.schema.ts
@@ -14,6 +14,10 @@ export const configSchema = z
             .string()
             .default('false')
             .transform((val) => val === 'true'),
+        TBLOCKER_NOTIFY_ALWAYS: z
+            .string()
+            .default('false')
+            .transform((val) => val === 'true'),
         INTERNAL_REST_TOKEN: z.string(),
         INTERNAL_SOCKET_PATH: z.string(),
         XTLS_API_SOCKET_PATH: z.string(),

--- a/src/modules/_plugin/events/xray-webhook/xray-webhook.handler.ts
+++ b/src/modules/_plugin/events/xray-webhook/xray-webhook.handler.ts
@@ -52,8 +52,10 @@ export class XrayWebhookHandler implements IEventHandler<XrayWebhookEvent> {
             let blocked = false;
 
             try {
-                await this.nftService.blockIp(ip, blockDuration);
-                blocked = true;
+                if (this.nftService.isAvailable) {
+                    await this.nftService.blockIp(ip, blockDuration);
+                    blocked = true;
+                }
 
                 this.logger.log(
                     `[TORRENT-BLOCKER] IP: ${ip}, user: ${webhook.email}, blocked: ${blocked}, duration: ${blockDuration}s`,

--- a/src/modules/_plugin/plugin.service.ts
+++ b/src/modules/_plugin/plugin.service.ts
@@ -179,7 +179,7 @@ export class PluginService {
     private syncTorrentBlocker(pluginData: TNodePlugin, sharedMap: Map<string, string[]>): void {
         if (!pluginData.torrentBlocker) return;
         if (!pluginData.torrentBlocker.enabled) return;
-        if (!this.nftService.isAvailable) return;
+        if (!this.state.plugins.torrentBlocker) return;
 
         const { blockDuration, ignoreLists } = pluginData.torrentBlocker;
 
@@ -191,8 +191,14 @@ export class PluginService {
         this.state.torrentBlocker.configure(blockDuration);
         this.state.torrentBlocker.setIncludeRuleTags(pluginData.torrentBlocker.includeRuleTags);
 
+        if (!this.nftService.isAvailable) {
+            this.logger.warn(
+                '[PLUGIN] Torrent-Blocker: notification only (nft unavailable) — reports on, IP block off',
+            );
+        }
+
         this.logger.log(
-            `[PLUGIN] Torrent-Blocker: blockDuration=${blockDuration}s, ${ips.length} ignored IPs, ${users.length} ignored users`,
+            `[PLUGIN] Torrent-Blocker: blockDuration=${blockDuration}s, ${ips.length} ignored IPs, ${users.length} ignored users, nftBlock=${this.nftService.isAvailable}`,
         );
     }
 

--- a/src/modules/_plugin/services/nft.service.ts
+++ b/src/modules/_plugin/services/nft.service.ts
@@ -2,6 +2,7 @@ import { hasCapNetAdmin } from 'sockdestroy';
 import { NftManager } from 'nftables-napi';
 
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { EventBus } from '@nestjs/cqrs';
 
 import { ICommandResponse } from '@common/types/command-response.type';
@@ -17,10 +18,12 @@ export class NftService implements OnModuleDestroy, OnModuleInit {
     private readonly logger = new Logger(NftService.name);
     private nftManager: NftManager | null = null;
     private available = false;
+    private notifyAlways = false;
 
     constructor(
         private readonly state: PluginStateService,
         private readonly eventBus: EventBus,
+        private readonly configService: ConfigService,
     ) {}
 
     get isAvailable(): boolean {
@@ -29,13 +32,25 @@ export class NftService implements OnModuleDestroy, OnModuleInit {
 
     public async onModuleInit(): Promise<void> {
         const capNetAdmin = hasCapNetAdmin();
+        this.notifyAlways = this.configService.getOrThrow<boolean>('TBLOCKER_NOTIFY_ALWAYS');
 
-        if (!capNetAdmin) return;
+        if (!capNetAdmin) {
+            if (this.notifyAlways) {
+                this.state.setPlugins({
+                    connectionDrop: false,
+                    ingressFilter: false,
+                    torrentBlocker: true,
+                    egressFilter: false,
+                });
+                this.logAvailablePlugins();
+            }
+            return;
+        }
 
         this.state.setPlugins({
             connectionDrop: true,
             ingressFilter: false,
-            torrentBlocker: false,
+            torrentBlocker: this.notifyAlways,
             egressFilter: false,
         });
 
@@ -62,6 +77,16 @@ export class NftService implements OnModuleDestroy, OnModuleInit {
         } catch (error) {
             this.logger.error(error);
             this.logger.warn('[PLUGIN] NftManager initialization failed.');
+            this.nftManager = null;
+            this.available = false;
+            if (this.notifyAlways) {
+                this.state.setPlugins({
+                    connectionDrop: true,
+                    ingressFilter: false,
+                    torrentBlocker: true,
+                    egressFilter: false,
+                });
+            }
         }
 
         this.logAvailablePlugins();
@@ -133,7 +158,11 @@ export class NftService implements OnModuleDestroy, OnModuleInit {
             { name: 'Connection Drop', enabled: plugins.connectionDrop },
         ].forEach((plugin) => {
             if (plugin.enabled) {
-                this.logger.log(`[PLUGIN] ${plugin.name}: available`);
+                if (plugin.name === 'Torrent Blocker' && this.notifyAlways && !this.available) {
+                    this.logger.warn(`[PLUGIN] ${plugin.name}: notification only`);
+                } else {
+                    this.logger.log(`[PLUGIN] ${plugin.name}: available`);
+                }
             } else {
                 this.logger.warn(`[PLUGIN] ${plugin.name}: not available`);
             }

--- a/src/modules/xray-core/xray.service.ts
+++ b/src/modules/xray-core/xray.service.ts
@@ -15,7 +15,7 @@ import { getSystemInfo, getSystemStats } from '@common/utils/get-system-stats';
 import { ICommandResponse } from '@common/types/command-response.type';
 import { generateApiConfig } from '@common/utils/generate-api-config';
 import { StartXrayCommand } from '@libs/contracts/commands';
-import { KNOWN_ERRORS } from '@libs/contracts/constants';
+import { KNOWN_ERRORS, XRAY_TORRENT_BLOCKER_OUTBOUND_TAG } from '@libs/contracts/constants';
 
 import {
     GetNodeHealthCheckResponseModel,
@@ -117,6 +117,10 @@ export class XrayService implements OnApplicationBootstrap {
         this.isXrayStartedProccesing = true;
 
         try {
+            const isTorrentBlockerEnabled = await this.queryBus.execute(
+                new GetTorrentBlockerStateQuery(),
+            );
+
             if (this.isXrayOnline && !this.disableHashedSetCheck && !body.internals.forceRestart) {
                 const { isOk } = await this.xtlsSdk.stats.getSysStats();
 
@@ -129,6 +133,17 @@ export class XrayService implements OnApplicationBootstrap {
                     shouldRestart = true;
 
                     this.logger.warn(`Xray Core health check failed, restarting...`);
+                }
+
+                if (
+                    !shouldRestart &&
+                    isTorrentBlockerEnabled.enabled &&
+                    !this.hasTorrentBlockerOutbound(await this.internalService.getXrayConfig())
+                ) {
+                    shouldRestart = true;
+                    this.logger.warn(
+                        'Torrent-Blocker is enabled but missing from Xray config, restarting...',
+                    );
                 }
 
                 if (!shouldRestart) {
@@ -150,10 +165,6 @@ export class XrayService implements OnApplicationBootstrap {
             if (body.internals.forceRestart) {
                 this.logger.warn('Force restart requested');
             }
-
-            const isTorrentBlockerEnabled = await this.queryBus.execute(
-                new GetTorrentBlockerStateQuery(),
-            );
 
             const fullConfig = generateApiConfig({
                 config: body.xrayConfig,
@@ -318,6 +329,21 @@ export class XrayService implements OnApplicationBootstrap {
         } catch (error) {
             this.logger.log(`s6: Failed to stop Xray process. Error: ${error}`);
         }
+    }
+
+    private hasTorrentBlockerOutbound(config: Record<string, unknown>): boolean {
+        const outbounds = config.outbounds;
+        if (!Array.isArray(outbounds)) {
+            return false;
+        }
+
+        return outbounds.some(
+            (outbound) =>
+                typeof outbound === 'object' &&
+                outbound !== null &&
+                'tag' in outbound &&
+                outbound.tag === XRAY_TORRENT_BLOCKER_OUTBOUND_TAG,
+        );
     }
 
     private getXrayVersionFromEnv(): null | string {


### PR DESCRIPTION
Adds optional TBLOCKER_NOTIFY_ALWAYS=true mode: Torrent Blocker continues to generate reports even when CAP_NET_ADMIN is unavailable or nft initialization fails.
In this mode IP blocking is skipped and reports contain blocked: false; default behavior is unchanged.